### PR TITLE
EVP-8455 Add a unique ID to the payload, to identify the LTI launch

### DIFF
--- a/classes/local_yuja/yuja_client.class.php
+++ b/classes/local_yuja/yuja_client.class.php
@@ -150,11 +150,11 @@ class yuja_client
      * @param string|int $courseid
      * @return string
      */
-    public function get_signed_videos_url($courseid) {
+    public function get_signed_videos_url($courseid, $uniquelaunchid) {
         $url = $this->get_yuja_videos_url();
         return $url . '?' . $this->get_query(
             $this->get_signed_lti_params(
-                $url, 'GET', $courseid, array('ext_content_return_types' => 'lti_api;moodle-media-chooser'))
+                $url, 'GET', $courseid, array('ext_content_return_types' => 'lti_api;moodle-media-chooser', 'unique_launch_id' => $uniquelaunchid))
         );
     }
 
@@ -163,11 +163,11 @@ class yuja_client
      * @param string|int $courseid
      * @return string
      */
-    public function get_signed_js_url($courseid) {
+    public function get_signed_js_url($courseid, $uniquelaunchid) {
         $url = $this->get_yuja_videos_url();
         return $url . '?' . $this->get_query(
             $this->get_signed_lti_params(
-                $url, 'GET', $courseid, array('ext_content_return_types' => 'lti_api;moodle-media-chooser-js'))
+                $url, 'GET', $courseid, array('ext_content_return_types' => 'lti_api;moodle-media-chooser-js', 'unique_launch_id' => $uniquelaunchid))
         );
     }
 
@@ -176,14 +176,15 @@ class yuja_client
      * @return array
      */
     public function get_texteditor_params() {
-        global $COURSE;
+        global $COURSE, $USER;
 
         $params = array();
 
         if ($this->has_lti_config() && isset($COURSE->id)) {
             try {
-                $params['yujaVideosUrl'] = $this->get_signed_videos_url($COURSE->id);
-                $params['yujaJsUrl'] = $this->get_signed_js_url($COURSE->id);
+                $uniquelaunchid = uniqid($USER->id.'_'.$COURSE->id.'_', true);
+                $params['yujaVideosUrl'] = $this->get_signed_videos_url($COURSE->id, $uniquelaunchid);
+                $params['yujaJsUrl'] = $this->get_signed_js_url($COURSE->id, $uniquelaunchid);
             } catch (Exception $e) {
                 $param['yujaError'] = $e->getMessage();
             }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die('Must access from moodle');
 
 $plugin                     = new stdClass();
-$plugin->version            = 2023062600;
+$plugin->version            = 2023092600;
 $plugin->requires           = 2012120300;
 $plugin->component          = 'local_yuja';
 $plugin->release            = '1.0.0';


### PR DESCRIPTION
- From a single media chooser launch, the unique ID is passed to both calls to our LTI server (the videos endpoint and the js endpoint). Both calls rely on each other to launch the media chooser. In the case of disabled cookies, it can lead to session persistence issues. The unique ID is used to identify the correct session.