### PR TITLE
Add LTI message hint fallback and bump version

### DIFF
--- a/classes/local_yuja/yuja_client.class.php
+++ b/classes/local_yuja/yuja_client.class.php
@@ -303,6 +303,8 @@ class yuja_client
         $ltihint['uniquelaunchid'] = $uniquelaunchid;
         $ltihint['courseid'] = $courseid;
         $ltihint['typeid'] = $config->typeid;
+        $ltihint['messagetype'] = $messagetype;
+        $ltihint['foruserid'] = $foruserid;
         $ltihint['titleb64'] = base64_encode($title);
         $ltihint['textb64'] = base64_encode($text);
         // If SSL is forced make sure https is on the normal launch URL.

--- a/classes/local_yuja/yuja_client.class.php
+++ b/classes/local_yuja/yuja_client.class.php
@@ -301,6 +301,10 @@ class yuja_client
         
         $ltihint['launchid'] = $launchid;
         $ltihint['uniquelaunchid'] = $uniquelaunchid;
+        $ltihint['courseid'] = $courseid;
+        $ltihint['typeid'] = $config->typeid;
+        $ltihint['titleb64'] = base64_encode($title);
+        $ltihint['textb64'] = base64_encode($text);
         // If SSL is forced make sure https is on the normal launch URL.
         if (isset($config->lti_forcessl) && ($config->lti_forcessl == '1')) {
             $endpoint = lti_ensure_url_is_https($endpoint);

--- a/lib/auth.php
+++ b/lib/auth.php
@@ -76,7 +76,22 @@ if ($ok && ($responsetype !== 'id_token')) {
 }
 if ($ok) {
     $launchid = $ltimessagehint->launchid;
-    list($courseid, $typeid, $messagetype, $foruserid, $titleb64, $textb64) = explode(',', $SESSION->$launchid, 7);
+    if (isset($SESSION->$launchid)) {
+        list($courseid, $typeid, $messagetype, $foruserid, $titleb64, $textb64) = explode(',', $SESSION->$launchid, 7);
+    } else if (isset($ltimessagehint->courseid) && isset($ltimessagehint->typeid)) {
+        $courseid = $ltimessagehint->courseid;
+        $typeid = $ltimessagehint->typeid;
+        $messagetype = $ltimessagehint->messagetype;
+        $foruserid = $ltimessagehint->foruserid;
+        $titleb64 = $ltimessagehint->titleb64;
+        $textb64 = $ltimessagehint->textb64; 
+    } else {
+        $ok = false;
+        $error = 'invalid_request';
+        $desc = 'No launch context available';
+    }
+}
+if ($ok) {
     $config = lti_get_type_type_config($typeid);
     $ok = ($clientid === $config->lti_clientid);
     if (!$ok) {

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die('Must access from moodle');
 
 $plugin                     = new stdClass();
-$plugin->version            = 2025043000;
+$plugin->version            = 2026070901;
 $plugin->requires           = 2012120300;
 $plugin->component          = 'local_yuja';
 $plugin->release            = '2.0.0';


### PR DESCRIPTION
Populate ltihint with courseid, typeid, messagetype, foruserid, titleb64 and textb64 (base64-encoded title/text) in yuja_client so the launch context can be reconstructed. Update auth flow to use SESSION->$launchid when available and fall back to ltimessagehint fields if the session entry is missing, returning an error if neither is present.